### PR TITLE
Fix typo in  test_trainer.py

### DIFF
--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -67,7 +67,7 @@ class AnnotatedL1Loss(nn.L1Loss):
     def __init__(self, *args, **kwargs):
         super(type(self),self).__init__(*args, **kwargs)
     def forward(self, input: torch.Tensor, target):
-        return super(type(self),self).forward(input=intput,target=target)
+        return super(type(self),self).forward(input=input,target=target)
 
 optimizer = ( 'SGD', {
     'lr' : 1e-3,


### PR DESCRIPTION
Hey, fixed typo in:
`vortex/tests/test_trainer.py:70:53: F821 undefined name 'intput'`