### PR TITLE
Add disable image auto padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - change `scheduler` to `lr_scheduler` in `config.trainer`.
   - change field `validation` to `validator` and move it from `config.trainer` to main `config`.
 - Refactor `DatasetWrapper` into `BasicDatasetWrapper` and `DefaultDatasetWrapper`
+- It is now possible to override image auto padding in dataset object by adding and set `self.disable_image_auto_pad = True` attribute on the `collate_fn` object provided by the `model_components`
 
 
 ## v0.1.0

--- a/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
+++ b/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
@@ -8,9 +8,9 @@ model : {
   preprocess_args : {
     input_size : 512,
     input_normalization : {
-      mean : [0.5, 0.5, 0.5],
-      std : [0.5, 0.5, 0.5],
-      scaler: 255,
+      mean : [0, 0, 0],
+      std : [1, 1, 1],
+      scaler: 1,
     }
   },
   network_args : {
@@ -73,25 +73,25 @@ dataset : {
     args : {
       image_set : train,
     },
-    augmentations : [{
-      module : albumentations,
-      args : {
-        transforms : [
-          {compose : OneOf, args : {
-            transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
-                          {transform : RandomSnow, args : {p : 0.5}}
-            ],
-            p : 0.5}},
-          {transform : HorizontalFlip, args : {p : 0.5}},
-          {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
-        ],
-        bbox_params : {
-          min_visibility : 0.0,
-          min_area : 0.0
-        },
-        visual_debug : False
-      }
-    }]
+    # augmentations : [{
+    #   module : albumentations,
+    #   args : {
+    #     transforms : [
+    #       {compose : OneOf, args : {
+    #         transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
+    #                       {transform : RandomSnow, args : {p : 0.5}}
+    #         ],
+    #         p : 0.5}},
+    #       {transform : HorizontalFlip, args : {p : 0.5}},
+    #       {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
+    #     ],
+    #     bbox_params : {
+    #       min_visibility : 0.0,
+    #       min_area : 0.0
+    #     },
+    #     visual_debug : False
+    #   }
+    # }]
   },
   eval : {
     name: VOC2007DetectionDataset,
@@ -101,9 +101,10 @@ dataset : {
   },
 }
 dataloader: {
-  module: PytorchDataLoader,
+  module: DALIDataLoader,
   args: {
-    num_workers: 0,
+    num_thread: 1,
+    device_id: 0,
     batch_size: 4,
     shuffle: True,
   },

--- a/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
+++ b/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
@@ -8,9 +8,9 @@ model : {
   preprocess_args : {
     input_size : 512,
     input_normalization : {
-      mean : [0, 0, 0],
-      std : [1, 1, 1],
-      scaler: 1,
+      mean : [0.5, 0.5, 0.5],
+      std : [0.5, 0.5, 0.5],
+      scaler: 255,
     }
   },
   network_args : {
@@ -73,25 +73,25 @@ dataset : {
     args : {
       image_set : train,
     },
-    # augmentations : [{
-    #   module : albumentations,
-    #   args : {
-    #     transforms : [
-    #       {compose : OneOf, args : {
-    #         transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
-    #                       {transform : RandomSnow, args : {p : 0.5}}
-    #         ],
-    #         p : 0.5}},
-    #       {transform : HorizontalFlip, args : {p : 0.5}},
-    #       {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
-    #     ],
-    #     bbox_params : {
-    #       min_visibility : 0.0,
-    #       min_area : 0.0
-    #     },
-    #     visual_debug : False
-    #   }
-    # }]
+    augmentations : [{
+      module : albumentations,
+      args : {
+        transforms : [
+          {compose : OneOf, args : {
+            transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
+                          {transform : RandomSnow, args : {p : 0.5}}
+            ],
+            p : 0.5}},
+          {transform : HorizontalFlip, args : {p : 0.5}},
+          {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
+        ],
+        bbox_params : {
+          min_visibility : 0.0,
+          min_area : 0.0
+        },
+        visual_debug : False
+      }
+    }]
   },
   eval : {
     name: VOC2007DetectionDataset,
@@ -101,10 +101,9 @@ dataset : {
   },
 }
 dataloader: {
-  module: DALIDataLoader,
+  module: PytorchDataLoader,
   args: {
-    num_thread: 1,
-    device_id: 0,
+    num_workers: 0,
     batch_size: 4,
     shuffle: True,
   },

--- a/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
+++ b/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
@@ -73,25 +73,25 @@ dataset : {
     args : {
       image_set : train,
     },
-    augmentations : [{
-      module : albumentations,
-      args : {
-        transforms : [
-          {compose : OneOf, args : {
-            transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
-                          {transform : RandomSnow, args : {p : 0.5}}
-            ],
-            p : 0.5}},
-          {transform : HorizontalFlip, args : {p : 0.5}},
-          {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
-        ],
-        bbox_params : {
-          min_visibility : 0.0,
-          min_area : 0.0
-        },
-        visual_debug : False
-      }
-    }]
+    # augmentations : [{
+    #   module : albumentations,
+    #   args : {
+    #     transforms : [
+    #       {compose : OneOf, args : {
+    #         transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
+    #                       {transform : RandomSnow, args : {p : 0.5}}
+    #         ],
+    #         p : 0.5}},
+    #       {transform : HorizontalFlip, args : {p : 0.5}},
+    #       {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
+    #     ],
+    #     bbox_params : {
+    #       min_visibility : 0.0,
+    #       min_area : 0.0
+    #     },
+    #     visual_debug : False
+    #   }
+    # }]
   },
   eval : {
     name: VOC2007DetectionDataset,
@@ -101,9 +101,10 @@ dataset : {
   },
 }
 dataloader: {
-  module: PytorchDataLoader,
+  module: DALIDataLoader,
   args: {
-    num_workers: 0,
+    num_thread: 1,
+    device_id: 0,
     batch_size: 4,
     shuffle: True,
   },

--- a/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
+++ b/experiments/configs/shufflenetv2x100_fpn_ssd_voc2007_512.yml
@@ -73,25 +73,25 @@ dataset : {
     args : {
       image_set : train,
     },
-    # augmentations : [{
-    #   module : albumentations,
-    #   args : {
-    #     transforms : [
-    #       {compose : OneOf, args : {
-    #         transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
-    #                       {transform : RandomSnow, args : {p : 0.5}}
-    #         ],
-    #         p : 0.5}},
-    #       {transform : HorizontalFlip, args : {p : 0.5}},
-    #       {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
-    #     ],
-    #     bbox_params : {
-    #       min_visibility : 0.0,
-    #       min_area : 0.0
-    #     },
-    #     visual_debug : False
-    #   }
-    # }]
+    augmentations : [{
+      module : albumentations,
+      args : {
+        transforms : [
+          {compose : OneOf, args : {
+            transforms : [{transform : RandomBrightnessContrast, args : {p : 0.5}},
+                          {transform : RandomSnow, args : {p : 0.5}}
+            ],
+            p : 0.5}},
+          {transform : HorizontalFlip, args : {p : 0.5}},
+          {transform : RandomScale, args : {scale_limit : 0.3, p : 0.5,}}
+        ],
+        bbox_params : {
+          min_visibility : 0.0,
+          min_area : 0.0
+        },
+        visual_debug : False
+      }
+    }]
   },
   eval : {
     name: VOC2007DetectionDataset,
@@ -101,10 +101,9 @@ dataset : {
   },
 }
 dataloader: {
-  module: DALIDataLoader,
+  module: PytorchDataLoader,
   args: {
-    num_thread: 1,
-    device_id: 0,
+    num_workers: 0,
     batch_size: 4,
     shuffle: True,
   },

--- a/vortex/core/factory.py
+++ b/vortex/core/factory.py
@@ -354,7 +354,6 @@ def create_dataloader(dataloader_config : EasyDict,
 
         # Re-initialize dataset (Temp workaround), adding `disable_image_auto_pad` to collate_fn object 
         # to disable auto pad augmentation
-        import pdb; pdb.set_trace()
         if hasattr(collate_fn,'disable_image_auto_pad'):
             dataset = create_dataset(dataset_config=dataset_config, 
                                      stage=stage, 

--- a/vortex/core/factory.py
+++ b/vortex/core/factory.py
@@ -211,8 +211,7 @@ def create_runtime_model(model_path : Union[str, Path],
 def create_dataset(dataset_config : EasyDict,
                    preprocess_config : EasyDict,
                    stage : str,
-                   wrapper_format : str = 'default',
-                   disable_image_auto_pad : bool = False
+                   wrapper_format : str = 'default'
                    ):
     dataset_config = deepcopy(dataset_config)
     augmentations = []
@@ -248,7 +247,7 @@ def create_dataset(dataset_config : EasyDict,
         raise RuntimeError('Unknown dataset `wrapper_format`, should be either "default" or "basic", got {} '.format(wrapper_format))
 
     return dataset_wrapper(dataset=dataset, stage=stage, preprocess_args=preprocess_config,
-                          augmentations=augmentations, dataset_args=dataset_args, disable_image_auto_pad=disable_image_auto_pad)
+                          augmentations=augmentations, dataset_args=dataset_args)
 
 def create_dataloader(dataloader_config : EasyDict,
                       dataset_config : EasyDict, 
@@ -355,12 +354,8 @@ def create_dataloader(dataloader_config : EasyDict,
         # Re-initialize dataset (Temp workaround), adding `disable_image_auto_pad` to collate_fn object 
         # to disable auto pad augmentation
         if hasattr(collate_fn,'disable_image_auto_pad'):
-            dataset = create_dataset(dataset_config=dataset_config, 
-                                     stage=stage, 
-                                     preprocess_config=preprocess_config,
-                                     wrapper_format=wrapper_format[dataloader_module],
-                                     disable_image_auto_pad=collate_fn.disable_image_auto_pad)
-
+            if collate_fn.disable_image_auto_pad:
+                dataset.disable_image_auto_pad()
 
     elif not (hasattr(collate_fn, '__call__') or collate_fn is None):
         raise TypeError("Unknown type of 'collate_fn', should be in the type of string, "

--- a/vortex/core/factory.py
+++ b/vortex/core/factory.py
@@ -354,7 +354,8 @@ def create_dataloader(dataloader_config : EasyDict,
 
         # Re-initialize dataset (Temp workaround), adding `disable_image_auto_pad` to collate_fn object 
         # to disable auto pad augmentation
-        if hasattr(collate_fn,'disable_image_auto_padding'):
+        import pdb; pdb.set_trace()
+        if hasattr(collate_fn,'disable_image_auto_pad'):
             dataset = create_dataset(dataset_config=dataset_config, 
                                      stage=stage, 
                                      preprocess_config=preprocess_config,

--- a/vortex/train.py
+++ b/vortex/train.py
@@ -13,7 +13,8 @@ def main(args):
 
     ckpt_in_cfg = 'checkpoint' in config
     if ckpt_in_cfg:
-        config.checkpoint = config.checkpoint.rstrip(',')
+        if config.checkpoint is not None:
+            config.checkpoint = config.checkpoint.rstrip(',')
     if args.resume and (not ckpt_in_cfg or (ckpt_in_cfg and config.checkpoint == None)):
         ## TODO: point to documentation for resume
         raise RuntimeError("You choose to resume but 'checkpoint' is not specified. "

--- a/vortex/utils/data/collater/__init__.py
+++ b/vortex/utils/data/collater/__init__.py
@@ -25,7 +25,13 @@ def create_collater(collater : str, *args, **kwargs) :
         raise KeyError("collater %s not supported, available : %s" %(collater, ALL_COLLATERS))
     for module, collaters in supported_collater.items() :
         if collater in collaters :
-            return module.create_collater(collater, *args, **kwargs)
+            collater_obj = module.create_collater(collater, *args, **kwargs)
+            if not hasattr(collater_obj,'disable_image_auto_pad'):
+                try:
+                    collater_obj.disable_image_auto_pad = False
+                except:
+                    pass
+            return collater_obj
     raise RuntimeError("unexpected error! please report this as bug")
 
 ## for maintainer, register your module here :

--- a/vortex/utils/data/collater/ssd.py
+++ b/vortex/utils/data/collater/ssd.py
@@ -11,7 +11,6 @@ class SSDCollate:
     def __init__(self, dataformat: dict) :
         ## TODO : check all necessary fields
         self.dataformat = EasyDict(dataformat)
-        self.disable_image_auto_pad = True
     
     def __call__(self, batch) :
         imgs, targets = list(zip(*batch))

--- a/vortex/utils/data/collater/ssd.py
+++ b/vortex/utils/data/collater/ssd.py
@@ -11,9 +11,11 @@ class SSDCollate:
     def __init__(self, dataformat: dict) :
         ## TODO : check all necessary fields
         self.dataformat = EasyDict(dataformat)
+        # self.disable_image_auto_pad = True
     
     def __call__(self, batch) :
         imgs, targets = list(zip(*batch))
+        # import pdb; pdb.set_trace()
         df = self.dataformat
 
         list_targets = []

--- a/vortex/utils/data/collater/ssd.py
+++ b/vortex/utils/data/collater/ssd.py
@@ -11,9 +11,11 @@ class SSDCollate:
     def __init__(self, dataformat: dict) :
         ## TODO : check all necessary fields
         self.dataformat = EasyDict(dataformat)
+        self.disable_image_auto_pad = True
     
     def __call__(self, batch) :
         imgs, targets = list(zip(*batch))
+        import pdb; pdb.set_trace()
         df = self.dataformat
 
         list_targets = []

--- a/vortex/utils/data/collater/ssd.py
+++ b/vortex/utils/data/collater/ssd.py
@@ -15,7 +15,6 @@ class SSDCollate:
     
     def __call__(self, batch) :
         imgs, targets = list(zip(*batch))
-        import pdb; pdb.set_trace()
         df = self.dataformat
 
         list_targets = []

--- a/vortex/utils/data/collater/ssd.py
+++ b/vortex/utils/data/collater/ssd.py
@@ -11,11 +11,9 @@ class SSDCollate:
     def __init__(self, dataformat: dict) :
         ## TODO : check all necessary fields
         self.dataformat = EasyDict(dataformat)
-        # self.disable_image_auto_pad = True
     
     def __call__(self, batch) :
         imgs, targets = list(zip(*batch))
-        # import pdb; pdb.set_trace()
         df = self.dataformat
 
         list_targets = []

--- a/vortex/utils/data/dataset/wrapper/basic_wrapper.py
+++ b/vortex/utils/data/dataset/wrapper/basic_wrapper.py
@@ -16,7 +16,6 @@ class BasicDatasetWrapper():
                  preprocess_args: Union[EasyDict, dict],
                  augmentations: Union[Tuple[str, dict]],
                  dataset_args: Union[EasyDict, dict] = {},
-                 disable_image_auto_pad : bool = False
                  ):
         """A basic form of dataset wrapper, maintain type checking and data format from integrated dataset
 
@@ -30,7 +29,7 @@ class BasicDatasetWrapper():
         self.stage = stage
         self.preprocess_args = preprocess_args
         self.augmentations_list = augmentations
-        self.disable_image_auto_pad = disable_image_auto_pad
+        self.image_auto_pad = True
 
         if stage == 'train' and self.augmentations_list is not None:
             if not isinstance(self.augmentations_list, List):
@@ -92,6 +91,9 @@ class BasicDatasetWrapper():
             raise RuntimeError("Unknown target return of %s" % type(target))
 
         return image,target
+    
+    def disable_image_auto_pad(self):
+        self.image_auto_pad = False
 
 def check_data_format_standard(data_format: EasyDict):
     def _convert_indices_to_list(indices: EasyDict):

--- a/vortex/utils/data/dataset/wrapper/basic_wrapper.py
+++ b/vortex/utils/data/dataset/wrapper/basic_wrapper.py
@@ -16,6 +16,7 @@ class BasicDatasetWrapper():
                  preprocess_args: Union[EasyDict, dict],
                  augmentations: Union[Tuple[str, dict]],
                  dataset_args: Union[EasyDict, dict] = {},
+                 disable_image_auto_pad : bool = False
                  ):
         """A basic form of dataset wrapper, maintain type checking and data format from integrated dataset
 
@@ -29,6 +30,7 @@ class BasicDatasetWrapper():
         self.stage = stage
         self.preprocess_args = preprocess_args
         self.augmentations_list = augmentations
+        self.disable_image_auto_pad = disable_image_auto_pad
 
         if stage == 'train' and self.augmentations_list is not None:
             if not isinstance(self.augmentations_list, List):

--- a/vortex/utils/data/dataset/wrapper/default_wrapper.py
+++ b/vortex/utils/data/dataset/wrapper/default_wrapper.py
@@ -36,12 +36,15 @@ class DefaultDatasetWrapper(BasicDatasetWrapper):
 
     def __init__(self, dataset: str, stage: str, preprocess_args: Union[EasyDict, dict],
                  augmentations: Union[Tuple[str, dict], List, Callable] = None,
-                 dataset_args: Union[EasyDict, dict] = {}):
+                 dataset_args: Union[EasyDict, dict] = {},
+                 disable_image_auto_pad : bool = False
+                 ):
         super().__init__(dataset=dataset,
                          stage=stage,
                          preprocess_args=preprocess_args,
                          augmentations=augmentations,
-                         dataset_args=dataset_args
+                         dataset_args=dataset_args,
+                         disable_image_auto_pad=disable_image_auto_pad
                          )
         # Configured computer vision augmentation initialization
         self.augments = None

--- a/vortex/utils/data/dataset/wrapper/default_wrapper.py
+++ b/vortex/utils/data/dataset/wrapper/default_wrapper.py
@@ -69,11 +69,19 @@ class DefaultDatasetWrapper(BasicDatasetWrapper):
         standard_tf_kwargs.data_format = self.data_format
         standard_tf_kwargs.transforms = [
             {'transform': 'LongestMaxSize', 'args': {'max_size': preprocess_args.input_size}},
-            {'transform': 'PadIfNeeded', 'args': {'min_height': preprocess_args.input_size,
+            # {'transform': 'PadIfNeeded', 'args': {'min_height': preprocess_args.input_size,
+            #                                       'min_width': preprocess_args.input_size,
+            #                                       'border_mode': cv2.BORDER_CONSTANT,
+            #                                       'value': [0, 0, 0]}},
+        ]
+
+        if not disable_image_auto_pad:
+            standard_tf_kwargs.transforms.append(
+                 {'transform': 'PadIfNeeded', 'args': {'min_height': preprocess_args.input_size,
                                                   'min_width': preprocess_args.input_size,
                                                   'border_mode': cv2.BORDER_CONSTANT,
                                                   'value': [0, 0, 0]}},
-        ]
+            )
         self.standard_augments = create_transform(
             'albumentations', **standard_tf_kwargs)
 

--- a/vortex/utils/data/loader/nvidia_dali_loader.py
+++ b/vortex/utils/data/loader/nvidia_dali_loader.py
@@ -45,7 +45,7 @@ class DALIDataloader():
                                        device_id=device_id)
 
         self.dataset = iterator.dataset
-        self.disable_image_auto_pad = self.dataset.disable_image_auto_pad
+        self.image_auto_pad = self.dataset.image_auto_pad
         self.data_format = dataset.data_format
         self.preprocess_args = iterator.dataset.preprocess_args
 
@@ -90,7 +90,7 @@ class DALIDataloader():
                 self.external_executors = [ExternalAugmentsExecutor.remote(transforms_list_ref,
                                                                   data_format_ref,
                                                                   preprocess_args_ref,
-                                                                  self.disable_image_auto_pad) for i in range(batch_size)]
+                                                                  self.image_auto_pad) for i in range(batch_size)]
 
 
         pipeline = DALIExternalSourcePipeline(dataset_iterator = iterator,
@@ -129,7 +129,7 @@ class DALIDataloader():
             # DALI still have flaws about padding image to square, this is the workaround by bringing the image shape before padding
             pre_padded_image_size = output['pre_padded_image_shape'][i].cpu()[:2].type(torch.float32)
             
-            if not self.disable_image_auto_pad:
+            if self.image_auto_pad:
                 input_size = self.preprocess_args.input_size
                 padded_image_size = torch.tensor([input_size,input_size]).type(torch.float32)
                 diff_ratio = pre_padded_image_size/padded_image_size
@@ -149,7 +149,7 @@ class DALIDataloader():
                 if layout == 'original_labels':
                     ret_targets = label_output
                 else:
-                    if not self.disable_image_auto_pad:
+                    if self.image_auto_pad:
                         # DALI still have flaws about padding image to square, 
                         # this is the workaround by bringing the image shape before padding
                         label_output = self._fix_coordinates(label_output,layout,diff_ratio)
@@ -240,7 +240,7 @@ class ExternalAugmentsExecutor():
                  transforms_list : list,
                  data_format : dict,
                  preprocess_args : dict,
-                 disable_image_auto_pad : bool = False):
+                 image_auto_pad : bool = True):
         """Initialization
 
         Args:
@@ -258,12 +258,8 @@ class ExternalAugmentsExecutor():
         standard_tf_kwargs.data_format = self.data_format
         standard_tf_kwargs.transforms = [
             {'transform': 'LongestMaxSize', 'args': {'max_size': preprocess_args.input_size}},
-            # {'transform': 'PadIfNeeded', 'args': {'min_height': preprocess_args.input_size,
-            #                                       'min_width': preprocess_args.input_size,
-            #                                       'border_mode': cv2.BORDER_CONSTANT,
-            #                                       'value': [0, 0, 0]}},
         ]
-        if not disable_image_auto_pad:
+        if image_auto_pad:
             standard_tf_kwargs.transforms.append(
             {'transform': 'PadIfNeeded', 'args': {'min_height': preprocess_args.input_size,
                                                   'min_width': preprocess_args.input_size,


### PR DESCRIPTION
## Type of changes

<!-- Put an `x` in the boxes that apply. Try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?
There is no mechanism to disable standard augmentations which enforce padding to square

- close #48 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Due to code structure limitations, create dataset need to be initialized twice if the collate_fn object have `disable_image_auto_pad` attributes
- Using this feature, developer can disable standard augments (padding) by adding `disable_image_auto_pad` attribute to the `collate_fn` class
-

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] Unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have filled the `[Unreleased]` [Changelog](https://github.com/nodefluxio/vortex/blob/master/CHANGELOG.md)
